### PR TITLE
Fix image deletion

### DIFF
--- a/lambda/static/js/past_uploads.js
+++ b/lambda/static/js/past_uploads.js
@@ -173,7 +173,7 @@ function deleteSelected(e) {
 }
 
 function deleteImage(name, callback) {
-    xmlHttp = new XMLHttpRequest();
+    var xmlHttp = new XMLHttpRequest();
     xmlHttp.onreadystatechange = function(e) {
         if (e.target.readyState === 4) callback();
     };

--- a/lambda/static/js/past_uploads.js
+++ b/lambda/static/js/past_uploads.js
@@ -173,8 +173,10 @@ function deleteSelected(e) {
 }
 
 function deleteImage(name, callback) {
-  xmlHttp = new XMLHttpRequest();
-  xmlHttp.onreadystatechange = callback;
-  xmlHttp.open("DELETE", "/file/" + name, true);
-  xmlHttp.send();
+    xmlHttp = new XMLHttpRequest();
+    xmlHttp.onreadystatechange = function(e) {
+        if (e.target.readyState === 4) callback();
+    };
+    xmlHttp.open("DELETE", "/file/" + name, true);
+    xmlHttp.send();
 }


### PR DESCRIPTION
Actually wait for the delete request to finish before continuing.

Before, the callback was called when the request opened, not when it finished. This caused the page to reload before the deleting was done, leading to it not working in Firefox